### PR TITLE
Include information from libxml_get_last_error() in TempladoException message

### DIFF
--- a/src/Templado.php
+++ b/src/Templado.php
@@ -7,14 +7,19 @@ class Templado {
     public static function loadHtmlFile(FileName $fileName): Html {
         \libxml_use_internal_errors(true);
         \libxml_clear_errors();
+
         $dom                     = new DOMDocument();
         $dom->preserveWhiteSpace = false;
         $tmp                     = $dom->load($fileName->asString());
+        $error                   = \libxml_get_last_error();
+        $message                 = \sprintf("Loading file '%s' failed", $fileName->asString());
 
-        if (!$tmp || \libxml_get_last_error()) {
-            throw new TempladoException(
-                \sprintf("Loading file '%s' failed.", $fileName->asString())
-            );
+        if (!$tmp && $error === false) {
+            throw new TempladoException($message);
+        }
+
+        if ($error instanceof \LibXMLError) {
+            throw new TempladoException($message . ':' . \PHP_EOL . self::formatError($error));
         }
 
         return new Html($dom);
@@ -23,13 +28,30 @@ class Templado {
     public static function parseHtmlString(string $string): Html {
         \libxml_use_internal_errors(true);
         \libxml_clear_errors();
-        $dom = new DOMDocument();
-        $tmp = $dom->loadXML($string);
 
-        if (!$tmp || \libxml_get_last_error()) {
-            throw new TempladoException('Parsing string failed.');
+        $dom     = new DOMDocument();
+        $tmp     = $dom->loadXML($string);
+        $error   = \libxml_get_last_error();
+        $message = 'Parsing string failed';
+
+        if (!$tmp && $error === false) {
+            throw new TempladoException($message);
+        }
+
+        if ($error instanceof \LibXMLError) {
+            throw new TempladoException($message . ':' . \PHP_EOL . self::formatError($error));
         }
 
         return new Html($dom);
+    }
+
+    private static function formatError(\LibXMLError $error): string
+    {
+        return \sprintf(
+            '%s (Line %d, Column %d)',
+            \trim($error->message),
+            $error->line,
+            $error->column
+        );
     }
 }

--- a/tests/TempladoTest.php
+++ b/tests/TempladoTest.php
@@ -23,7 +23,7 @@ class TempladoTest extends TestCase {
      */
     public function testTryingToParseInvalidMarkupStringThrowsException(): void {
         $this->expectException(TempladoException::class);
-        $this->expectExceptionMessage('Premature end of data in tag root line 1 (Line 1, Column 29)');
+        $this->expectExceptionMessageMatches('/^Parsing string failed:\R.*Line.*Column.*$/m');
 
         Templado::parseHtmlString('<?xml version="1.0" ?><root>');
     }
@@ -34,7 +34,7 @@ class TempladoTest extends TestCase {
      */
     public function testTryingToLoadBrokenFileThrowsException(): void {
         $this->expectException(TempladoException::class);
-        $this->expectExceptionMessage('Premature end of data in tag start line 2 (Line 4, Column 1)');
+        $this->expectExceptionMessageMatches('/^Loading file.*failed:\R.*Line.*Column.*$/m');
 
         Templado::loadHtmlFile(new FileName(__DIR__ . '/_data/broken.txt'));
     }

--- a/tests/TempladoTest.php
+++ b/tests/TempladoTest.php
@@ -23,7 +23,10 @@ class TempladoTest extends TestCase {
      */
     public function testTryingToParseInvalidMarkupStringThrowsException(): void {
         $this->expectException(TempladoException::class);
-        $this->expectExceptionMessage('Premature end of data in tag root line 1 (Line 1, Column 29)');
+
+        if (version_compare('2.9.13', LIBXML_DOTTED_VERSION, '>=')) {
+            $this->expectExceptionMessage('Premature end of data in tag root line 1 (Line 1, Column 29)');
+        }
 
         Templado::parseHtmlString('<?xml version="1.0" ?><root>');
     }
@@ -34,7 +37,10 @@ class TempladoTest extends TestCase {
      */
     public function testTryingToLoadBrokenFileThrowsException(): void {
         $this->expectException(TempladoException::class);
-        $this->expectExceptionMessage('Premature end of data in tag start line 2 (Line 4, Column 1)');
+
+        if (version_compare('2.9.13', LIBXML_DOTTED_VERSION, '>=')) {
+            $this->expectExceptionMessage('Premature end of data in tag start line 2 (Line 4, Column 1)');
+        }
 
         Templado::loadHtmlFile(new FileName(__DIR__ . '/_data/broken.txt'));
     }

--- a/tests/TempladoTest.php
+++ b/tests/TempladoTest.php
@@ -23,10 +23,7 @@ class TempladoTest extends TestCase {
      */
     public function testTryingToParseInvalidMarkupStringThrowsException(): void {
         $this->expectException(TempladoException::class);
-
-        if (version_compare('2.9.13', LIBXML_DOTTED_VERSION, '>=')) {
-            $this->expectExceptionMessage('Premature end of data in tag root line 1 (Line 1, Column 29)');
-        }
+        $this->expectExceptionMessage('Premature end of data in tag root line 1 (Line 1, Column 29)');
 
         Templado::parseHtmlString('<?xml version="1.0" ?><root>');
     }
@@ -37,10 +34,7 @@ class TempladoTest extends TestCase {
      */
     public function testTryingToLoadBrokenFileThrowsException(): void {
         $this->expectException(TempladoException::class);
-
-        if (version_compare('2.9.13', LIBXML_DOTTED_VERSION, '>=')) {
-            $this->expectExceptionMessage('Premature end of data in tag start line 2 (Line 4, Column 1)');
-        }
+        $this->expectExceptionMessage('Premature end of data in tag start line 2 (Line 4, Column 1)');
 
         Templado::loadHtmlFile(new FileName(__DIR__ . '/_data/broken.txt'));
     }

--- a/tests/TempladoTest.php
+++ b/tests/TempladoTest.php
@@ -23,6 +23,8 @@ class TempladoTest extends TestCase {
      */
     public function testTryingToParseInvalidMarkupStringThrowsException(): void {
         $this->expectException(TempladoException::class);
+        $this->expectExceptionMessage('Premature end of data in tag root line 1 (Line 1, Column 29)');
+
         Templado::parseHtmlString('<?xml version="1.0" ?><root>');
     }
 
@@ -32,6 +34,8 @@ class TempladoTest extends TestCase {
      */
     public function testTryingToLoadBrokenFileThrowsException(): void {
         $this->expectException(TempladoException::class);
+        $this->expectExceptionMessage('Premature end of data in tag start line 2 (Line 4, Column 1)');
+
         Templado::loadHtmlFile(new FileName(__DIR__ . '/_data/broken.txt'));
     }
 


### PR DESCRIPTION
This PR changes `Templado::loadHtmlFile()` and `Templado::parseHtmlString()` to include information (line, column, message) from `libxml_get_last_error()` (if available) in the message string that is passed to `TempladoException`.

This is motivated by the "frustration" I recently experienced when I used `Templado::loadHtmlFile()` and a `TempladoException` bubbled all the way up and the resulting information printed by PHP was not helpful.

Only after implementing the changes proposed in this PR did I realize that `TempladoException::getErrorList()` exists. This method returns a list of `LibXMLError` objects that is captured when the `TempladoException` is created. That is useful, but does not result in a useful message when PHP prints information for uncaught exceptions.

An alternative to the changes proposed in this PR could be the implementation of `TempladoException::getMessage()`. That method could build a useful message based on the list of `LibXMLError` objects.