### PR TITLE
Inform that PHP >=7.4 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Templado
-A pragmatic approach to templating for PHP 7.x
+A pragmatic approach to templating for PHP >=7.4
 
 [![Integrate](https://github.com/templado/engine/workflows/Integrate/badge.svg)](https://github.com/templado/engine/actions)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name" : "templado/engine",
-  "description" : "A pragmatic approach to templating for PHP 7.2+",
+  "description" : "A pragmatic approach to templating for PHP >=7.4",
   "license" : "BSD-3-Clause",
   "authors" : [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2656dbd5be1dfc1fd290ace3e1b803a",
+    "content-hash": "668e283dc3dadfb407cb40fbcb4ee98d",
     "packages": [
         {
             "name": "theseer/css2xpath",
@@ -36,11 +36,15 @@
             "authors": [
                 {
                     "name": "Arne Blankerts",
-                    "role": "Developer",
-                    "email": "arne@blankerts.de"
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
             "description": "PHP Library to translate CSS selectors into XPath",
+            "support": {
+                "issues": "https://github.com/theseer/CSS2XPath/issues",
+                "source": "https://github.com/theseer/css2xpath/tree/2.0.0"
+            },
             "time": "2019-08-28T04:35:56+00:00"
         }
     ],
@@ -51,9 +55,10 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2|^8.0",
+        "php": "^7.4|^8.0",
         "ext-dom": "*",
         "ext-libxml": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
The `README.md`, `composer.json` and `composer.lock` all stated that PHP 7.2 is supported.  
But support for PHP 7.2 was dropped with https://github.com/templado/engine/commit/420edabc5365e720b0426e74fd6d6725973d4d4d

This pull requests updates the aforementioned files the state that PHP >= 7.4 is required