### PR TITLE
docs(README): state that Templado 4.x requires at least PHP >=7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A pragmatic approach to templating for PHP 8.2+
 
-(Use Templado [4.x](https://github.com/templado/engine/tree/4.x) for PHP 7+)
+(Use Templado [4.x](https://github.com/templado/engine/tree/4.x) for PHP >=7.4)
 
 ### Motivation
 


### PR DESCRIPTION
Support for PHP <7.4 was dropped.