### PR TITLE
Fix implicit null deprecation warnings for PHP 8.4

### DIFF
--- a/src/Html.php
+++ b/src/Html.php
@@ -107,7 +107,7 @@ class Html {
         return $list;
     }
 
-    public function asString(Filter $filter = null): string {
+    public function asString(?Filter $filter = null): string {
         $content = $this->serializeDomDocument();
         $content = (new EmptyElementsFilter())->apply($content);
         $content = (new ClearRedundantHtmlNamespaceDefinitionsFilter($this->dom->documentElement->nodeName))->apply($content);

--- a/src/TempladoException.php
+++ b/src/TempladoException.php
@@ -6,7 +6,7 @@ class TempladoException extends Exception {
     /** @var \LibXMLError[] */
     private $errorList;
 
-    public function __construct(string $message, int $code = 0, Exception $previous = null) {
+    public function __construct(string $message, int $code = 0, ?Exception $previous = null) {
         parent::__construct($message, $code, $previous);
         $this->errorList = \libxml_get_errors();
         \libxml_clear_errors();

--- a/src/snippet/SnippetLoader.php
+++ b/src/snippet/SnippetLoader.php
@@ -4,7 +4,7 @@ namespace Templado\Engine;
 use DOMDocument;
 
 class SnippetLoader {
-    public function load(FileName $fileName, string $id = null): Snippet {
+    public function load(FileName $fileName, ?string $id = null): Snippet {
         $this->ensureFileExists($fileName);
         $this->ensureIsReadableFile($fileName);
 
@@ -26,7 +26,7 @@ class SnippetLoader {
         );
     }
 
-    private function loadAsText(FileName $fileName, string $id = null): TextSnippet {
+    private function loadAsText(FileName $fileName, ?string $id = null): TextSnippet {
         return new TextSnippet(
             $id ?? $fileName->getName(),
             (new DOMDocument())->createTextNode(\file_get_contents($fileName->asString()))
@@ -36,7 +36,7 @@ class SnippetLoader {
     /**
      * @throws SnippetLoaderException
      */
-    private function loadAsSnippet(FileName $fileName, string $id = null): Snippet {
+    private function loadAsSnippet(FileName $fileName, ?string $id = null): Snippet {
         $dom = $this->loadFile($fileName);
 
         if ($this->isTempladoSnippetDocument($dom)) {
@@ -123,11 +123,11 @@ class SnippetLoader {
         }
     }
 
-    private function parseAsTempladoSnippet(DOMDocument $dom, string $id = null): TempladoSnippet {
+    private function parseAsTempladoSnippet(DOMDocument $dom, ?string $id = null): TempladoSnippet {
         return new TempladoSnippet($id ?? $dom->documentElement->getAttribute('id'), $dom);
     }
 
-    private function parseAsHTML(DOMDocument $dom, string $id = null): SimpleSnippet {
+    private function parseAsHTML(DOMDocument $dom, ?string $id = null): SimpleSnippet {
         $id = $id ?? $dom->documentElement->getAttribute('id');
 
         if ($id === '') {


### PR DESCRIPTION
Implicitly marking parameters as nullable has been deprecated as of PHP 8.4 